### PR TITLE
fix: (eks-mcp-server) prevent server from crashing on launch with inv…

### DIFF
--- a/src/eks-mcp-server/tests/test_aws_helper.py
+++ b/src/eks-mcp-server/tests/test_aws_helper.py
@@ -23,6 +23,11 @@ from unittest.mock import ANY, MagicMock, patch
 class TestAwsHelper:
     """Tests for the AwsHelper class."""
 
+    def setup_method(self):
+        """Set up the test environment."""
+        # Clear the client cache before each test
+        AwsHelper._client_cache = {}
+
     @patch.dict(os.environ, {'AWS_REGION': 'us-west-2'})
     def test_get_aws_region_from_env(self):
         """Test that get_aws_region returns the region from the environment."""
@@ -151,3 +156,107 @@ class TestAwsHelper:
                     assert config is not None
                     expected_user_agent = f'awslabs/mcp/eks-mcp-server/{__version__}'
                     assert config.user_agent_extra == expected_user_agent
+
+    @patch('boto3.client')
+    def test_client_caching(self, mock_boto3_client):
+        """Test that clients are cached and reused."""
+        # Create a mock client
+        mock_client = MagicMock()
+        mock_boto3_client.return_value = mock_client
+
+        # Mock the get_aws_profile and get_aws_region methods
+        with patch.object(AwsHelper, 'get_aws_profile', return_value=None):
+            with patch.object(AwsHelper, 'get_aws_region', return_value='us-west-2'):
+                # Call create_boto3_client twice with the same parameters
+                client1 = AwsHelper.create_boto3_client('cloudformation')
+                client2 = AwsHelper.create_boto3_client('cloudformation')
+
+                # Verify that boto3.client was called only once
+                mock_boto3_client.assert_called_once()
+
+                # Verify that the same client instance was returned both times
+                assert client1 is client2
+
+    @patch('boto3.client')
+    def test_different_services_not_cached_together(self, mock_boto3_client):
+        """Test that different services get different cached clients."""
+        # Create mock clients
+        mock_cf_client = MagicMock()
+        mock_s3_client = MagicMock()
+        mock_boto3_client.side_effect = [mock_cf_client, mock_s3_client]
+
+        # Mock the get_aws_profile and get_aws_region methods
+        with patch.object(AwsHelper, 'get_aws_profile', return_value=None):
+            with patch.object(AwsHelper, 'get_aws_region', return_value='us-west-2'):
+                # Call create_boto3_client for different services
+                cf_client = AwsHelper.create_boto3_client('cloudformation')
+                s3_client = AwsHelper.create_boto3_client('s3')
+
+                # Verify that boto3.client was called twice
+                assert mock_boto3_client.call_count == 2
+
+                # Verify that different client instances were returned
+                assert cf_client is not s3_client
+
+    @patch('boto3.client')
+    def test_same_service_different_regions_cached_together(self, mock_boto3_client):
+        """Test that clients for the same service are cached together regardless of region."""
+        # Create mock client
+        mock_client = MagicMock()
+        mock_boto3_client.return_value = mock_client
+
+        # Mock the get_aws_profile method
+        with patch.object(AwsHelper, 'get_aws_profile', return_value=None):
+            # Call create_boto3_client for different regions
+            us_west_client = AwsHelper.create_boto3_client(
+                'cloudformation', region_name='us-west-2'
+            )
+            eu_west_client = AwsHelper.create_boto3_client(
+                'cloudformation', region_name='eu-west-1'
+            )
+
+            # Verify that boto3.client was called only once
+            mock_boto3_client.assert_called_once()
+
+            # Verify that the same client instance was returned both times
+            assert us_west_client is eu_west_client
+
+    @patch('boto3.client')
+    def test_error_handling(self, mock_boto3_client):
+        """Test that errors during client creation are handled properly."""
+        # Make boto3.client raise an exception
+        mock_boto3_client.side_effect = Exception('Test error')
+
+        # Mock the get_aws_profile and get_aws_region methods
+        with patch.object(AwsHelper, 'get_aws_profile', return_value=None):
+            with patch.object(AwsHelper, 'get_aws_region', return_value=None):
+                # Verify that the exception is re-raised with more context
+                try:
+                    AwsHelper.create_boto3_client('cloudformation')
+                    assert False, 'Exception was not raised'
+                except Exception as e:
+                    assert 'Failed to create boto3 client for cloudformation: Test error' in str(e)
+
+    @patch('boto3.Session')
+    def test_same_service_different_profiles_cached_together(self, mock_boto3_session):
+        """Test that clients for the same service are cached together regardless of profile."""
+        # Create mock session and client
+        mock_session = MagicMock()
+        mock_client = MagicMock()
+        mock_session.client.return_value = mock_client
+        mock_boto3_session.return_value = mock_session
+
+        # Call create_boto3_client with different profiles
+        with patch.object(AwsHelper, 'get_aws_profile', return_value='profile1'):
+            with patch.object(AwsHelper, 'get_aws_region', return_value=None):
+                client1 = AwsHelper.create_boto3_client('cloudformation')
+
+        with patch.object(AwsHelper, 'get_aws_profile', return_value='profile2'):
+            with patch.object(AwsHelper, 'get_aws_region', return_value=None):
+                client2 = AwsHelper.create_boto3_client('cloudformation')
+
+        # Verify that boto3.Session was called only once
+        mock_boto3_session.assert_called_once()
+
+        # Verify that the same client instance was returned both times
+        assert client1 is client2

--- a/src/eks-mcp-server/tests/test_iam_handler.py
+++ b/src/eks-mcp-server/tests/test_iam_handler.py
@@ -22,20 +22,12 @@ from unittest.mock import MagicMock, patch
 
 
 @pytest.mark.asyncio
-@patch('awslabs.eks_mcp_server.aws_helper.AwsHelper.create_boto3_client')
-async def test_iam_handler_initialization(mock_create_client):
-    # Create a mock IAM client
-    mock_iam_client = MagicMock()
-    mock_create_client.return_value = mock_iam_client
-
+async def test_iam_handler_initialization():
     # Create a mock MCP server
     mock_mcp = MagicMock()
 
     # Initialize the IAM handler with the mock MCP server
     IAMHandler(mock_mcp, allow_write=True)
-
-    # Verify that create_boto3_client was called with 'iam'
-    mock_create_client.assert_called_once_with('iam')
 
     # Verify that all tools were registered
     assert mock_mcp.tool.call_count == 2
@@ -64,15 +56,8 @@ async def test_get_policies_for_role(mock_create_client):
     # Initialize the IAM handler with the mock MCP server
     handler = IAMHandler(mock_mcp)
 
-    # Verify that create_boto3_client was called with 'iam'
-    mock_create_client.assert_called_once_with('iam')
-
     # Create a mock context
     mock_ctx = MagicMock(spec=Context)
-
-    # Mock the IAM client
-    mock_iam_client = MagicMock()
-    handler.iam_client = mock_iam_client
 
     # Mock the get_role response
     mock_role_response = {
@@ -193,15 +178,8 @@ async def test_add_inline_policy_existing_policy(mock_create_client):
     # Initialize the IAM handler with the mock MCP server with write access enabled
     handler = IAMHandler(mock_mcp, allow_write=True)
 
-    # Verify that create_boto3_client was called with 'iam'
-    mock_create_client.assert_called_once_with('iam')
-
     # Create a mock context
     mock_ctx = MagicMock(spec=Context)
-
-    # Mock the IAM client
-    mock_iam_client = MagicMock()
-    handler.iam_client = mock_iam_client
 
     # Mock the get_role_policy response to indicate the policy already exists
     mock_role_policy_response = {
@@ -257,15 +235,8 @@ async def test_add_inline_policy_new_policy(mock_create_client):
     # Initialize the IAM handler with the mock MCP server with write access enabled
     handler = IAMHandler(mock_mcp, allow_write=True)
 
-    # Verify that create_boto3_client was called with 'iam'
-    mock_create_client.assert_called_once_with('iam')
-
     # Create a mock context
     mock_ctx = MagicMock(spec=Context)
-
-    # Mock the IAM client
-    mock_iam_client = MagicMock()
-    handler.iam_client = mock_iam_client
 
     # Mock the get_role_policy to raise NoSuchEntityException
     mock_iam_client.exceptions.NoSuchEntityException = Exception
@@ -320,15 +291,8 @@ async def test_add_inline_policy_multiple_statements(mock_create_client):
     # Initialize the IAM handler with the mock MCP server with write access enabled
     handler = IAMHandler(mock_mcp, allow_write=True)
 
-    # Verify that create_boto3_client was called with 'iam'
-    mock_create_client.assert_called_once_with('iam')
-
     # Create a mock context
     mock_ctx = MagicMock(spec=Context)
-
-    # Mock the IAM client
-    mock_iam_client = MagicMock()
-    handler.iam_client = mock_iam_client
 
     # Mock the get_role_policy to raise NoSuchEntityException
     mock_iam_client.exceptions.NoSuchEntityException = Exception
@@ -372,3 +336,348 @@ async def test_add_inline_policy_multiple_statements(mock_create_client):
     assert len(policy_document['Statement']) == 2
     assert policy_document['Statement'][0]['Action'] == 's3:PutObject'
     assert policy_document['Statement'][1]['Action'] == 's3:DeleteObject'
+
+
+@pytest.mark.asyncio
+@patch('awslabs.eks_mcp_server.aws_helper.AwsHelper.create_boto3_client')
+async def test_get_policies_for_role_error(mock_create_client):
+    """Test get_policies_for_role method when an error occurs."""
+    # Create a mock IAM client
+    mock_iam_client = MagicMock()
+    mock_create_client.return_value = mock_iam_client
+
+    # Make get_role raise an exception
+    mock_iam_client.get_role.side_effect = Exception('Role not found')
+
+    # Create a mock MCP server
+    mock_mcp = MagicMock()
+
+    # Initialize the IAM handler with the mock MCP server
+    handler = IAMHandler(mock_mcp)
+
+    # Create a mock context
+    mock_ctx = MagicMock(spec=Context)
+
+    # Call the get_policies_for_role method
+    result = await handler.get_policies_for_role(mock_ctx, role_name='non-existent-role')
+
+    # Verify the result indicates an error
+    assert result.isError
+    assert len(result.content) == 1
+    assert result.content[0].type == 'text'
+    assert 'Failed to describe IAM role' in result.content[0].text
+    assert 'Role not found' in result.content[0].text
+    assert result.role_arn == ''
+    assert result.assume_role_policy_document == {}
+    assert result.description is None
+    assert result.managed_policies == []
+    assert result.inline_policies == []
+
+
+@pytest.mark.asyncio
+@patch('awslabs.eks_mcp_server.aws_helper.AwsHelper.create_boto3_client')
+async def test_get_policies_for_role_string_policy_document(mock_create_client):
+    """Test get_policies_for_role method when assume_role_policy_document is a string."""
+    # Create a mock IAM client
+    mock_iam_client = MagicMock()
+    mock_create_client.return_value = mock_iam_client
+
+    # Mock the get_role response with a string policy document
+    mock_role_response = {
+        'Role': {
+            'RoleName': 'test-role',
+            'RoleId': 'AROAEXAMPLEID',
+            'Arn': 'arn:aws:iam::123456789012:role/test-role',
+            'Path': '/',
+            'CreateDate': MagicMock(isoformat=lambda: '2023-01-01T00:00:00Z'),
+            'AssumeRolePolicyDocument': '{"Version":"2012-10-17","Statement":[{"Effect":"Allow","Principal":{"Service":"eks.amazonaws.com"},"Action":"sts:AssumeRole"}]}',
+            'MaxSessionDuration': 3600,
+            'Description': 'Test role',
+            'Tags': [{'Key': 'Environment', 'Value': 'Test'}],
+        }
+    }
+    mock_iam_client.get_role.return_value = mock_role_response
+
+    # Mock the list_attached_role_policies response
+    mock_iam_client.list_attached_role_policies.return_value = {'AttachedPolicies': []}
+
+    # Mock the list_role_policies response
+    mock_iam_client.list_role_policies.return_value = {'PolicyNames': []}
+
+    # Create a mock MCP server
+    mock_mcp = MagicMock()
+
+    # Initialize the IAM handler with the mock MCP server
+    handler = IAMHandler(mock_mcp)
+
+    # Create a mock context
+    mock_ctx = MagicMock(spec=Context)
+
+    # Call the get_policies_for_role method
+    result = await handler.get_policies_for_role(mock_ctx, role_name='test-role')
+
+    # Verify the result
+    assert not result.isError
+    assert len(result.content) == 1
+    assert result.content[0].type == 'text'
+    assert 'Successfully retrieved details for IAM role: test-role' in result.content[0].text
+    assert result.role_arn == 'arn:aws:iam::123456789012:role/test-role'
+    assert result.description == 'Test role'
+    assert result.assume_role_policy_document == {
+        'Version': '2012-10-17',
+        'Statement': [
+            {
+                'Effect': 'Allow',
+                'Principal': {'Service': 'eks.amazonaws.com'},
+                'Action': 'sts:AssumeRole',
+            }
+        ],
+    }
+    assert result.managed_policies == []
+    assert result.inline_policies == []
+
+
+@pytest.mark.asyncio
+@patch('awslabs.eks_mcp_server.aws_helper.AwsHelper.create_boto3_client')
+async def test_get_managed_policies_error(mock_create_client):
+    """Test _get_managed_policies method when an error occurs."""
+    # Create a mock IAM client
+    mock_iam_client = MagicMock()
+    mock_create_client.return_value = mock_iam_client
+
+    # Mock the get_role response
+    mock_role_response = {
+        'Role': {
+            'RoleName': 'test-role',
+            'RoleId': 'AROAEXAMPLEID',
+            'Arn': 'arn:aws:iam::123456789012:role/test-role',
+            'Path': '/',
+            'CreateDate': MagicMock(isoformat=lambda: '2023-01-01T00:00:00Z'),
+            'AssumeRolePolicyDocument': {
+                'Version': '2012-10-17',
+                'Statement': [
+                    {
+                        'Effect': 'Allow',
+                        'Principal': {'Service': 'eks.amazonaws.com'},
+                        'Action': 'sts:AssumeRole',
+                    }
+                ],
+            },
+            'MaxSessionDuration': 3600,
+            'Description': 'Test role',
+            'Tags': [{'Key': 'Environment', 'Value': 'Test'}],
+        }
+    }
+    mock_iam_client.get_role.return_value = mock_role_response
+
+    # Mock the list_attached_role_policies response
+    mock_attached_policies_response = {
+        'AttachedPolicies': [
+            {
+                'PolicyName': 'AmazonEKSClusterPolicy',
+                'PolicyArn': 'arn:aws:iam::aws:policy/AmazonEKSClusterPolicy',
+            }
+        ]
+    }
+    mock_iam_client.list_attached_role_policies.return_value = mock_attached_policies_response
+
+    # Mock the get_policy response
+    mock_policy_response = {
+        'Policy': {
+            'PolicyName': 'AmazonEKSClusterPolicy',
+            'PolicyId': 'ANPAEXAMPLEID',
+            'Arn': 'arn:aws:iam::aws:policy/AmazonEKSClusterPolicy',
+            'Path': '/',
+            'DefaultVersionId': 'v1',
+            'AttachmentCount': 1,
+            'IsAttachable': True,
+            'CreateDate': MagicMock(isoformat=lambda: '2023-01-01T00:00:00Z'),
+            'UpdateDate': MagicMock(isoformat=lambda: '2023-01-01T00:00:00Z'),
+            'Description': 'Policy for EKS clusters',
+        }
+    }
+    mock_iam_client.get_policy.return_value = mock_policy_response
+
+    # Make get_policy_version raise an exception
+    mock_iam_client.get_policy_version.side_effect = Exception('Version not found')
+
+    # Mock the list_role_policies response
+    mock_iam_client.list_role_policies.return_value = {'PolicyNames': []}
+
+    # Create a mock MCP server
+    mock_mcp = MagicMock()
+
+    # Initialize the IAM handler with the mock MCP server
+    handler = IAMHandler(mock_mcp)
+
+    # Create a mock context
+    mock_ctx = MagicMock(spec=Context)
+
+    # Call the get_policies_for_role method
+    result = await handler.get_policies_for_role(mock_ctx, role_name='test-role')
+
+    # Verify the result
+    assert not result.isError
+    assert len(result.content) == 1
+    assert result.content[0].type == 'text'
+    assert 'Successfully retrieved details for IAM role: test-role' in result.content[0].text
+    assert result.role_arn == 'arn:aws:iam::123456789012:role/test-role'
+    assert result.description == 'Test role'
+    assert len(result.managed_policies) == 1
+    assert result.managed_policies[0].policy_type == 'Managed'
+    assert result.managed_policies[0].description == 'Policy for EKS clusters'
+    assert result.managed_policies[0].policy_document is None  # Should be None due to the error
+    assert result.inline_policies == []
+
+
+@pytest.mark.asyncio
+@patch('awslabs.eks_mcp_server.aws_helper.AwsHelper.create_boto3_client')
+async def test_get_inline_policies_error(mock_create_client):
+    """Test _get_inline_policies method when an error occurs."""
+    # Create a mock IAM client
+    mock_iam_client = MagicMock()
+    mock_create_client.return_value = mock_iam_client
+
+    # Mock the get_role response
+    mock_role_response = {
+        'Role': {
+            'RoleName': 'test-role',
+            'RoleId': 'AROAEXAMPLEID',
+            'Arn': 'arn:aws:iam::123456789012:role/test-role',
+            'Path': '/',
+            'CreateDate': MagicMock(isoformat=lambda: '2023-01-01T00:00:00Z'),
+            'AssumeRolePolicyDocument': {
+                'Version': '2012-10-17',
+                'Statement': [
+                    {
+                        'Effect': 'Allow',
+                        'Principal': {'Service': 'eks.amazonaws.com'},
+                        'Action': 'sts:AssumeRole',
+                    }
+                ],
+            },
+            'MaxSessionDuration': 3600,
+            'Description': 'Test role',
+            'Tags': [{'Key': 'Environment', 'Value': 'Test'}],
+        }
+    }
+    mock_iam_client.get_role.return_value = mock_role_response
+
+    # Mock the list_attached_role_policies response
+    mock_iam_client.list_attached_role_policies.return_value = {'AttachedPolicies': []}
+
+    # Mock the list_role_policies response
+    mock_inline_policies_response = {'PolicyNames': ['test-inline-policy']}
+    mock_iam_client.list_role_policies.return_value = mock_inline_policies_response
+
+    # Make get_role_policy raise an exception
+    mock_iam_client.get_role_policy.side_effect = Exception('Policy not found')
+
+    # Create a mock MCP server
+    mock_mcp = MagicMock()
+
+    # Initialize the IAM handler with the mock MCP server
+    handler = IAMHandler(mock_mcp)
+
+    # Create a mock context
+    mock_ctx = MagicMock(spec=Context)
+
+    # Call the get_policies_for_role method
+    result = await handler.get_policies_for_role(mock_ctx, role_name='test-role')
+
+    # Verify the result indicates an error
+    assert result.isError
+    assert len(result.content) == 1
+    assert result.content[0].type == 'text'
+    assert 'Failed to describe IAM role' in result.content[0].text
+    assert 'Policy not found' in result.content[0].text
+    assert result.role_arn == ''
+    assert result.assume_role_policy_document == {}
+    assert result.description is None
+    assert result.managed_policies == []
+    assert result.inline_policies == []
+
+
+@pytest.mark.asyncio
+@patch('awslabs.eks_mcp_server.aws_helper.AwsHelper.create_boto3_client')
+async def test_add_inline_policy_write_access_disabled(mock_create_client):
+    """Test add_inline_policy method when write access is disabled."""
+    # Create a mock IAM client
+    mock_iam_client = MagicMock()
+    mock_create_client.return_value = mock_iam_client
+
+    # Create a mock MCP server
+    mock_mcp = MagicMock()
+
+    # Initialize the IAM handler with the mock MCP server with write access disabled
+    handler = IAMHandler(mock_mcp, allow_write=False)
+
+    # Create a mock context
+    mock_ctx = MagicMock(spec=Context)
+
+    # Define the permissions to add
+    permissions = {
+        'Effect': 'Allow',
+        'Action': 's3:PutObject',
+        'Resource': 'arn:aws:s3:::example-bucket/*',
+    }
+
+    # Call the add_inline_policy method
+    result = await handler.add_inline_policy(
+        mock_ctx, policy_name='test-inline-policy', role_name='test-role', permissions=permissions
+    )
+
+    # Verify the result indicates an error because write access is disabled
+    assert result.isError
+    assert len(result.content) == 1
+    assert result.content[0].type == 'text'
+    assert 'Adding inline policies requires --allow-write flag' in result.content[0].text
+    assert result.policy_name == 'test-inline-policy'
+    assert result.role_name == 'test-role'
+    assert result.permissions_added == {}
+
+    # Verify that no AWS API calls were made
+    mock_create_client.assert_not_called()
+
+
+@pytest.mark.asyncio
+@patch('awslabs.eks_mcp_server.aws_helper.AwsHelper.create_boto3_client')
+async def test_add_inline_policy_general_error(mock_create_client):
+    """Test add_inline_policy method when a general error occurs."""
+    # Create a mock IAM client
+    mock_iam_client = MagicMock()
+    mock_create_client.return_value = mock_iam_client
+
+    # Make create_boto3_client raise an exception
+    mock_create_client.side_effect = Exception('AWS credentials not found')
+
+    # Create a mock MCP server
+    mock_mcp = MagicMock()
+
+    # Initialize the IAM handler with the mock MCP server with write access enabled
+    handler = IAMHandler(mock_mcp, allow_write=True)
+
+    # Create a mock context
+    mock_ctx = MagicMock(spec=Context)
+
+    # Define the permissions to add
+    permissions = {
+        'Effect': 'Allow',
+        'Action': 's3:PutObject',
+        'Resource': 'arn:aws:s3:::example-bucket/*',
+    }
+
+    # Call the add_inline_policy method
+    result = await handler.add_inline_policy(
+        mock_ctx, policy_name='test-inline-policy', role_name='test-role', permissions=permissions
+    )
+
+    # Verify the result indicates an error
+    assert result.isError
+    assert len(result.content) == 1
+    assert result.content[0].type == 'text'
+    assert 'Failed to create inline policy' in result.content[0].text
+    assert 'AWS credentials not found' in result.content[0].text
+    assert result.policy_name == 'test-inline-policy'
+    assert result.role_name == 'test-role'
+    assert result.permissions_added == {}


### PR DESCRIPTION
…alid AWS credentials (#574)

* fix: (eks-mcp-server) prevent server from crashing on launch with invalid credentials

* feat: add client cache to AwsHelper

* docs: improve _client_cache description

* fix: remove redundant TTL constant and AWS client caching from K8sClientCache

* docs: fix comment wording

* add unit tests to pass codecov

* add eks_stack_handler tests to improve code coverage

---------

<!-- markdownlint-disable MD041 MD043 -->
Fixes

## Summary

### Changes

> Please provide a summary of what's being changed

### User experience

> Please share what the user experience looks like before and after this change

## Checklist

If your change doesn't seem to apply, please leave them unchecked.

* [ ] I have reviewed the [contributing guidelines](https://github.com/awslabs/mcp/blob/main/CONTRIBUTING.md)
* [ ] I have performed a self-review of this change
* [ ] Changes have been tested
* [ ] Changes are documented

Is this a breaking change? (Y/N)

**RFC issue number**:

Checklist:

* [ ] Migration process documented
* [ ] Implement warnings (if it can live side by side)

## Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the [project license](https://github.com/awslabs/mcp/blob/main/LICENSE).
